### PR TITLE
Added support for 23.967 FPS 

### DIFF
--- a/scripts/ml_stopwatch.py
+++ b/scripts/ml_stopwatch.py
@@ -298,8 +298,8 @@ The fields on the right can be used for notes.''', menu=False) as win:
                 fieldMinValue=-1000, fieldMaxValue=1000,
                 changeCommand=self.uiUpdateStartFrame)
 
-            self.frameRateField = mc.intFieldGrp(label='Frame Rate', value1=self.frameRate, enable1=False, extraLabel='fps', annotation='')
-
+            self.frameRateField = mc.floatFieldGrp(label='Frame Rate', value1=self.frameRate, enable1=False, extraLabel='fps', annotation='', precision=3)
+            
             mc.scrollLayout()
             mc.rowColumnLayout(numberOfColumns=3, columnWidth=[(1, 50), (2, 80), (3, 340)])
             mc.text('Frame')

--- a/scripts/ml_utilities.py
+++ b/scripts/ml_utilities.py
@@ -432,7 +432,7 @@ def getCurrentCamera():
 
 def getFrameRate():
     '''
-    Return an int of the current frame rate
+    Return a float of the current frame rate.
     '''
     currentUnit = mc.currentUnit(query=True, time=True)
     if currentUnit == 'film':
@@ -448,7 +448,7 @@ def getFrameRate():
     if currentUnit == 'ntscf':
         return 60
     if 'fps' in currentUnit:
-        return int(currentUnit.replace('fps',''))
+        return float(currentUnit.replace('fps',''))
 
     return 1
 


### PR DESCRIPTION
Hey Morgan!

I was getting errors using 23.976 native maya frame rate in Maya 2023 with ml_setKeyframe.  I've made a couple of adjustments so it uses a float instead of int in utilities and stopwatch.  Hopefully this can be helpful for others too. :)

Cheers,
Henry